### PR TITLE
[feat] 배송 조회, 검색, 페이징 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.3.1'
+	id 'org.springframework.boot' version '3.2.5'
 	id 'io.spring.dependency-management' version '1.1.5'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,10 +29,12 @@ ext {
 }
 
 dependencies {
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ ext {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/logilink/eureka/client/delivery/common/BaseResponse.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/common/BaseResponse.java
@@ -1,7 +1,7 @@
 package com.logilink.eureka.client.delivery.common;
 
-import com.sparta.logilinkcommon.common.exception.AppException;
-import com.sparta.logilinkcommon.common.exception.ErrorResponse;
+
+import com.logilink.eureka.client.delivery.common.exception.AppException;
 import lombok.*;
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/logilink/eureka/client/delivery/common/BaseResponse.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/common/BaseResponse.java
@@ -1,0 +1,34 @@
+package com.logilink.eureka.client.delivery.common;
+
+import com.sparta.logilinkcommon.common.exception.AppException;
+import com.sparta.logilinkcommon.common.exception.ErrorResponse;
+import lombok.*;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class BaseResponse<T> {
+
+    private boolean isSuccess;
+    private String message;
+    private HttpStatus status;
+    private T result;
+
+//    // 요청에 성공한 경우
+//    private BaseResponse(T result) {
+//        this.isAuccess = true;
+//        this.message = "요청에 성공했습니다.";
+//        this.status = HttpStatus.OK;
+//        this.result = result;
+//    }
+
+    public static <T> BaseResponse<T> success(T data) {
+        return new BaseResponse<>(true, "요청이 성공했습니다.", HttpStatus.OK, data);
+    }
+
+    public static BaseResponse<AppException> fail(AppException exception) {
+        return new BaseResponse<>(false, "요청이 실패했습니다.", exception.getStatus(), exception);
+    }
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/common/BaseTimeEntity.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/common/BaseTimeEntity.java
@@ -1,0 +1,42 @@
+package com.logilink.eureka.client.delivery.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+
+    @CreatedBy
+    @Column(updatable = false, nullable = false)
+    private Long createdBy;
+
+    @LastModifiedBy
+    private Long updatedBy;
+
+    private Long deletedBy;
+
+    public void softDelete(LocalDateTime deletedAt, Long deletedBy) {
+        this.deletedAt = deletedAt;
+        this.deletedBy = deletedBy;
+    }
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/common/constants/DeliveryStatus.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/common/constants/DeliveryStatus.java
@@ -1,0 +1,24 @@
+package com.logilink.eureka.client.delivery.common.constants;
+
+import lombok.Getter;
+
+/**
+ * 배송 상태
+ */
+@Getter
+public enum DeliveryStatus {
+
+    HUB_PENDING("허브 대기중"),
+    MIDDLE_HUB_PENDING("중간 허브 대기중"),
+    TO_HUB("허브 이동중"),
+    DESTINATION_HUB_ARRIVED("목적지 허브 도착"),
+    MIDDLE_HUB_ARRIVED("중간 허브 도착"),
+    TO_COMPANY("업체 이동중"),
+    DONE("배송완료");
+
+    private final String status;
+
+    DeliveryStatus(String status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/common/constants/DeliveryUserType.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/common/constants/DeliveryUserType.java
@@ -1,0 +1,19 @@
+package com.logilink.eureka.client.delivery.common.constants;
+
+import lombok.Getter;
+
+/**
+ * 배송 담당 타입
+ */
+@Getter
+public enum DeliveryUserType {
+
+    HUB("허브"),
+    COMPANY("업체");
+
+    private final String type;
+
+    DeliveryUserType(String type) {
+        this.type = type;
+    }
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/common/exception/ApiErrorCode.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/common/exception/ApiErrorCode.java
@@ -1,0 +1,22 @@
+package com.logilink.eureka.client.delivery.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ApiErrorCode implements ErrorCode {
+    INVALID_REQUEST("API001", "잘못된 요청입니다.", HttpStatus.FORBIDDEN),
+    FORBIDDEN("API002", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    UNAUTHORIZED("API003", "인증이 필요합니다.", HttpStatus.UNAUTHORIZED)
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+
+    ApiErrorCode(String code, String message, HttpStatus status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/common/exception/AppException.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/common/exception/AppException.java
@@ -1,0 +1,27 @@
+package com.logilink.eureka.client.delivery.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class AppException extends RuntimeException{
+
+    private final HttpStatus status;
+    private final String code;
+
+    public AppException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.code = errorCode.getCode();
+        this.status = errorCode.getStatus();
+    }
+
+    protected AppException(HttpStatus httpStatus, String code, String message) {
+        super(message);
+        this.code = code;
+        this.status = httpStatus;
+    }
+
+    public static AppException of(ErrorCode errorCode) {
+        return new AppException(errorCode);
+    }
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/common/exception/ErrorCode.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/common/exception/ErrorCode.java
@@ -1,0 +1,9 @@
+package com.logilink.eureka.client.delivery.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String getCode();
+    String getMessage();
+    HttpStatus getStatus();
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/common/exception/ErrorResponse.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/common/exception/ErrorResponse.java
@@ -1,0 +1,29 @@
+package com.logilink.eureka.client.delivery.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+public record ErrorResponse(
+        String code,
+        String message,
+        @JsonInclude(JsonInclude.Include.NON_NULL) List<ErrorField> errors
+) {
+
+    public static ErrorResponse from(AppException appException) {
+        return new ErrorResponse(appException.getCode(), appException.getMessage(), null);
+    }
+
+    public static ErrorResponse from(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), null);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, List<ErrorField> errors) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), errors);
+    }
+
+    public record ErrorField(Object value, String message) {
+
+    }
+
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.logilink.eureka.client.delivery.common.exception;
 
-import com.sparta.logilinkcommon.common.BaseResponse;
+import com.logilink.eureka.client.delivery.common.BaseResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;

--- a/src/main/java/com/logilink/eureka/client/delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,43 @@
+package com.logilink.eureka.client.delivery.common.exception;
+
+import com.sparta.logilinkcommon.common.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AppException.class)
+    public ResponseEntity<BaseResponse> handleException(AppException exception) {
+        return ResponseEntity.status(exception.getStatus())
+                .body(BaseResponse.fail(exception));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleException(
+            MethodArgumentNotValidException exception) {
+        List<ErrorResponse.ErrorField> errorFields = exception.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(fieldError -> new ErrorResponse.ErrorField(
+                        fieldError.getField(),
+                        fieldError.getDefaultMessage()))
+                .toList();
+
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.of(ApiErrorCode.INVALID_REQUEST, errorFields));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleException() {
+        return ResponseEntity
+                .badRequest()
+                .body(ErrorResponse.from(ApiErrorCode.INVALID_REQUEST));
+    }
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/controller/DeliveryController.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/controller/DeliveryController.java
@@ -1,15 +1,28 @@
 package com.logilink.eureka.client.delivery.domain.controller;
 
+import com.logilink.eureka.client.delivery.common.BaseResponse;
+import com.logilink.eureka.client.delivery.domain.model.Delivery;
+import com.logilink.eureka.client.delivery.domain.model.dto.RequestDto;
 import com.logilink.eureka.client.delivery.domain.service.DeliveryService;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
 @Slf4j
+@RequestMapping("/api/v1")
 public class DeliveryController {
     private final DeliveryService deliveryService;
+
+    // Todo. 게이트웨이 체인에 orderId 넣어주는지, 아님 프론트에서 넘겨주는걸로 가도 되는지 확인
+    @PostMapping("/deliveries/{orderId}")
+    public BaseResponse createDelivery(@PathVariable UUID orderId, @RequestBody RequestDto requestDto) {
+        Delivery result = deliveryService.createDelivery(orderId, requestDto);
+        return BaseResponse.success(result);
+    }
 
 }

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/controller/DeliveryController.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/controller/DeliveryController.java
@@ -4,12 +4,19 @@ import com.logilink.eureka.client.delivery.common.BaseResponse;
 import com.logilink.eureka.client.delivery.common.constants.DeliveryStatus;
 import com.logilink.eureka.client.delivery.domain.model.Delivery;
 import com.logilink.eureka.client.delivery.domain.model.dto.CreateRequestDto;
+import com.logilink.eureka.client.delivery.domain.model.dto.SearchDeliveryResponseDto;
 import com.logilink.eureka.client.delivery.domain.model.dto.UpdateRequestDto;
 import com.logilink.eureka.client.delivery.domain.service.DeliveryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -32,6 +39,39 @@ public class DeliveryController {
     public BaseResponse updateDelivery(@PathVariable UUID deliveryId, @RequestBody UpdateRequestDto updateRequestDto) {
         Delivery delivery = deliveryService.updateDelivery(deliveryId, updateRequestDto);
         return BaseResponse.success(delivery);
+    }
+
+    // 배송 단건 조회
+    @GetMapping("/deliveries/{deliveryId}")
+    public BaseResponse getDelivery(@PathVariable UUID deliveryId) {
+        Delivery delivery = deliveryService.getDelivery(deliveryId);
+        return BaseResponse.success(delivery);
+    }
+
+    // 배송 목록 조회
+    @GetMapping("/deliveries")
+    public BaseResponse getDeliveryPage(@RequestParam(required = false) String direction,
+                                        @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC)
+                                              Pageable pageable) {
+        if (direction != null) {
+            Sort.Direction sortDirection = Sort.Direction.fromString(direction);
+            pageable = PageRequest.of(
+                    pageable.getPageNumber(),
+                    pageable.getPageSize(),
+                    Sort.by(sortDirection, "createdAt")
+            );
+        }
+
+        Page<Delivery> deliveryList = deliveryService.getDeliveryList(pageable);
+        return BaseResponse.success(deliveryList);
+    }
+
+    //배송 현황 검색
+    @GetMapping("search-deliveries/{orderId}")
+    public BaseResponse searchDeliveryStatusList(@PathVariable UUID orderId){
+        List<SearchDeliveryResponseDto> responseDtoList = deliveryService.searchDeliveryStatusList(orderId);
+        return BaseResponse.success(responseDtoList);
+
     }
 
     // 배송 삭제

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/controller/DeliveryController.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/controller/DeliveryController.java
@@ -2,9 +2,8 @@ package com.logilink.eureka.client.delivery.domain.controller;
 
 import com.logilink.eureka.client.delivery.common.BaseResponse;
 import com.logilink.eureka.client.delivery.domain.model.Delivery;
-import com.logilink.eureka.client.delivery.domain.model.dto.RequestDto;
+import com.logilink.eureka.client.delivery.domain.model.dto.CreateRequestDto;
 import com.logilink.eureka.client.delivery.domain.service.DeliveryService;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -20,8 +19,8 @@ public class DeliveryController {
 
     // Todo. 게이트웨이 체인에 orderId 넣어주는지, 아님 프론트에서 넘겨주는걸로 가도 되는지 확인
     @PostMapping("/deliveries/{orderId}")
-    public BaseResponse createDelivery(@PathVariable UUID orderId, @RequestBody RequestDto requestDto) {
-        Delivery result = deliveryService.createDelivery(orderId, requestDto);
+    public BaseResponse createDelivery(@PathVariable UUID orderId, @RequestBody CreateRequestDto createRequestDto) {
+        Delivery result = deliveryService.createDelivery(orderId, createRequestDto);
         return BaseResponse.success(result);
     }
 

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/controller/DeliveryController.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/controller/DeliveryController.java
@@ -1,8 +1,10 @@
 package com.logilink.eureka.client.delivery.domain.controller;
 
 import com.logilink.eureka.client.delivery.common.BaseResponse;
+import com.logilink.eureka.client.delivery.common.constants.DeliveryStatus;
 import com.logilink.eureka.client.delivery.domain.model.Delivery;
 import com.logilink.eureka.client.delivery.domain.model.dto.CreateRequestDto;
+import com.logilink.eureka.client.delivery.domain.model.dto.UpdateRequestDto;
 import com.logilink.eureka.client.delivery.domain.service.DeliveryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,10 +20,20 @@ public class DeliveryController {
     private final DeliveryService deliveryService;
 
     // Todo. 게이트웨이 체인에 orderId 넣어주는지, 아님 프론트에서 넘겨주는걸로 가도 되는지 확인
+    // 배송 생성
     @PostMapping("/deliveries/{orderId}")
     public BaseResponse createDelivery(@PathVariable UUID orderId, @RequestBody CreateRequestDto createRequestDto) {
-        Delivery result = deliveryService.createDelivery(orderId, createRequestDto);
-        return BaseResponse.success(result);
+        Delivery delivery = deliveryService.createDelivery(orderId, createRequestDto);
+        return BaseResponse.success(delivery);
     }
+
+    // 배송 수정
+    @PatchMapping("/deliveries/{deliveryId}")
+    public BaseResponse updateDelivery(@PathVariable UUID deliveryId, @RequestBody UpdateRequestDto updateRequestDto) {
+        Delivery delivery = deliveryService.updateDelivery(deliveryId, updateRequestDto);
+        return BaseResponse.success(delivery);
+    }
+
+
 
 }

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/controller/DeliveryController.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/controller/DeliveryController.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@NoArgsConstructor
 @RequiredArgsConstructor
 @Slf4j
 public class DeliveryController {

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/controller/DeliveryController.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/controller/DeliveryController.java
@@ -34,6 +34,14 @@ public class DeliveryController {
         return BaseResponse.success(delivery);
     }
 
+    // 배송 삭제
+    @DeleteMapping("/deliveries/{deliveryId}")
+    public BaseResponse deleteDelivery(@PathVariable UUID deliveryId) {
+        // Todo. 토큰/체인에서 유저 아이디 빼와서 넘겨주기 (권한 : 마스터, 허브 관리자)
+        Long userId = 1111L;
 
+        Delivery delivery = deliveryService.deleteDelivery(deliveryId, userId);
+        return BaseResponse.success(delivery);
+    }
 
 }

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/controller/DeliveryController.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/controller/DeliveryController.java
@@ -1,0 +1,16 @@
+package com.logilink.eureka.client.delivery.domain.controller;
+
+import com.logilink.eureka.client.delivery.domain.service.DeliveryService;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@NoArgsConstructor
+@RequiredArgsConstructor
+@Slf4j
+public class DeliveryController {
+    private final DeliveryService deliveryService;
+
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/model/Delivery.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/model/Delivery.java
@@ -1,14 +1,10 @@
 package com.logilink.eureka.client.delivery.domain.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.logilink.eureka.client.delivery.common.BaseTimeEntity;
 import com.logilink.eureka.client.delivery.common.constants.DeliveryStatus;
-import com.logilink.eureka.client.delivery.domain.model.dto.RequestDto;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.*;
-import reactor.util.annotation.Nullable;
 
 import java.util.UUID;
 
@@ -21,12 +17,15 @@ import java.util.UUID;
 @AllArgsConstructor
 public class Delivery extends BaseTimeEntity {
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
     @Column(name = "is_hub_delivery", nullable = false)
+    @JsonProperty("isHubDelivery")
     private boolean isHubDelivery;
 
     @Column(name = "delivery_status")
+    @Enumerated(EnumType.STRING)
     private DeliveryStatus status;
 
     @Column(name = "origin_hub_id", nullable = false)
@@ -42,7 +41,7 @@ public class Delivery extends BaseTimeEntity {
     private Long deliveryManagerId;
 
     @Column(name = "route_id", nullable = false)
-    private UUID routdId;
+    private UUID routeId;
 
     @Column(name = "order_id", nullable = false)
     private UUID orderId;

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/model/Delivery.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/model/Delivery.java
@@ -2,14 +2,13 @@ package com.logilink.eureka.client.delivery.domain.model;
 
 import com.logilink.eureka.client.delivery.common.BaseTimeEntity;
 import com.logilink.eureka.client.delivery.common.constants.DeliveryStatus;
+import com.logilink.eureka.client.delivery.domain.model.dto.RequestDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+import reactor.util.annotation.Nullable;
 
 import java.util.UUID;
 
@@ -17,34 +16,34 @@ import java.util.UUID;
 @Table(name = "p_deliveries")
 @Getter
 @Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Delivery extends BaseTimeEntity {
     @Id
     private UUID id;
 
-    @Column(name = "is_hub_delivery")
+    @Column(name = "is_hub_delivery", nullable = false)
     private boolean isHubDelivery;
 
     @Column(name = "delivery_status")
     private DeliveryStatus status;
 
-    @Column(name = "origin_hub_id")
-    private UUID origiHubId;
+    @Column(name = "origin_hub_id", nullable = false)
+    private UUID originHubId;
 
-    @Column(name = "destination_id")
+    @Column(name = "destination_id", nullable = false)
     private UUID destinationId;
 
-    @Column(name = "destination_address")
+    @Column(name = "destination_address", nullable = false)
     private String destinationAddress;
 
     @Column(name = "deliery_manager_id")
     private Long deliveryManagerId;
 
-    @Column(name = "route_id")
+    @Column(name = "route_id", nullable = false)
     private UUID routdId;
 
-    @Column(name = "order_id")
+    @Column(name = "order_id", nullable = false)
     private UUID orderId;
-
 }

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/model/Delivery.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/model/Delivery.java
@@ -1,0 +1,50 @@
+package com.logilink.eureka.client.delivery.domain.model;
+
+import com.logilink.eureka.client.delivery.common.BaseTimeEntity;
+import com.logilink.eureka.client.delivery.common.constants.DeliveryStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_deliveries")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Delivery extends BaseTimeEntity {
+    @Id
+    private UUID id;
+
+    @Column(name = "is_hub_delivery")
+    private boolean isHubDelivery;
+
+    @Column(name = "delivery_status")
+    private DeliveryStatus status;
+
+    @Column(name = "origin_hub_id")
+    private UUID origiHubId;
+
+    @Column(name = "destination_id")
+    private UUID destinationId;
+
+    @Column(name = "destination_address")
+    private String destinationAddress;
+
+    @Column(name = "deliery_manager_id")
+    private Long deliveryManagerId;
+
+    @Column(name = "route_id")
+    private UUID routdId;
+
+    @Column(name = "order_id")
+    private UUID orderId;
+
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/model/Delivery.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/model/Delivery.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 @AllArgsConstructor
 public class Delivery extends BaseTimeEntity {
     @Id
+    //@Column(name = "delivery_id", columnDefinition = "uuid")
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/model/JpaConfig.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/model/JpaConfig.java
@@ -1,0 +1,18 @@
+package com.logilink.eureka.client.delivery.domain.model;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.util.Optional;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+    @Bean
+    public AuditorAware<Long> auditorAware() {
+        return () -> Optional.of(1L); // 임시 더미 유저 ID
+    }
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/model/dto/CreateRequestDto.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/model/dto/CreateRequestDto.java
@@ -1,21 +1,28 @@
 package com.logilink.eureka.client.delivery.domain.model.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.logilink.eureka.client.delivery.common.constants.DeliveryStatus;
 import com.logilink.eureka.client.delivery.domain.model.Delivery;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.UUID;
 
-public class RequestDto {
-    @NotBlank(message = "베송 타입은 필수입니다.")
+@Getter
+@Setter
+public class CreateRequestDto {
+    @NotNull(message = "베송 타입은 필수입니다.")
+    @JsonProperty("isHubDelivery")
     private boolean isHubDelivery;
 
     private DeliveryStatus status;
 
-    @NotBlank(message = "출발 허브는 필수입니다.")
+    @NotNull(message = "출발 허브는 필수입니다.")
     private UUID originHubId;
 
-    @NotBlank(message = "도착지는 필수입니다.")
+    @NotNull(message = "도착지는 필수입니다.")
     private UUID destinationId;
 
     @NotBlank(message = "도착지 주소는 필수입니다.")
@@ -23,7 +30,7 @@ public class RequestDto {
 
     private Long deliveryManagerId;
 
-    @NotBlank(message = "경로 아이디는 필수입니다.")
+    @NotNull(message = "경로 아이디는 필수입니다.")
     private UUID routeId;
 
     public Delivery toDelivery() {
@@ -34,7 +41,7 @@ public class RequestDto {
                 .destinationId(destinationId)
                 .destinationAddress(destinationAddress)
                 .deliveryManagerId(deliveryManagerId)
-                .routdId(routeId).build();
+                .routeId(routeId).build();
     }
 
 }

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/model/dto/RequestDto.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/model/dto/RequestDto.java
@@ -1,4 +1,40 @@
 package com.logilink.eureka.client.delivery.domain.model.dto;
 
+import com.logilink.eureka.client.delivery.common.constants.DeliveryStatus;
+import com.logilink.eureka.client.delivery.domain.model.Delivery;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.UUID;
+
 public class RequestDto {
+    @NotBlank(message = "베송 타입은 필수입니다.")
+    private boolean isHubDelivery;
+
+    private DeliveryStatus status;
+
+    @NotBlank(message = "출발 허브는 필수입니다.")
+    private UUID originHubId;
+
+    @NotBlank(message = "도착지는 필수입니다.")
+    private UUID destinationId;
+
+    @NotBlank(message = "도착지 주소는 필수입니다.")
+    private String destinationAddress;
+
+    private Long deliveryManagerId;
+
+    @NotBlank(message = "경로 아이디는 필수입니다.")
+    private UUID routeId;
+
+    public Delivery toDelivery() {
+        return Delivery.builder()
+                .isHubDelivery(isHubDelivery)
+                .status(status)
+                .originHubId(originHubId)
+                .destinationId(destinationId)
+                .destinationAddress(destinationAddress)
+                .deliveryManagerId(deliveryManagerId)
+                .routdId(routeId).build();
+    }
+
 }

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/model/dto/RequestDto.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/model/dto/RequestDto.java
@@ -1,0 +1,4 @@
+package com.logilink.eureka.client.delivery.domain.model.dto;
+
+public class RequestDto {
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/model/dto/ResponseDto.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/model/dto/ResponseDto.java
@@ -1,0 +1,4 @@
+package com.logilink.eureka.client.delivery.domain.model.dto;
+
+public class ResponseDto {
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/model/dto/ResponseDto.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/model/dto/ResponseDto.java
@@ -1,4 +1,0 @@
-package com.logilink.eureka.client.delivery.domain.model.dto;
-
-public class ResponseDto {
-}

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/model/dto/SearchDeliveryResponseDto.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/model/dto/SearchDeliveryResponseDto.java
@@ -1,0 +1,15 @@
+package com.logilink.eureka.client.delivery.domain.model.dto;
+
+import com.logilink.eureka.client.delivery.common.constants.DeliveryStatus;
+import lombok.AllArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Setter
+@AllArgsConstructor
+public class SearchDeliveryResponseDto {
+    private UUID deliveryId;
+    private DeliveryStatus status;
+    private UUID orderId;
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/model/dto/UpdateRequestDto.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/model/dto/UpdateRequestDto.java
@@ -1,0 +1,13 @@
+package com.logilink.eureka.client.delivery.domain.model.dto;
+
+import com.logilink.eureka.client.delivery.common.constants.DeliveryStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UpdateRequestDto {
+
+    private DeliveryStatus status;
+    private Long deliveryManagerId;
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/repository/DeliveryRepository.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/repository/DeliveryRepository.java
@@ -1,9 +1,14 @@
 package com.logilink.eureka.client.delivery.domain.repository;
 
 import com.logilink.eureka.client.delivery.domain.model.Delivery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface DeliveryRepository extends JpaRepository<Delivery, UUID> {
+    Page<Delivery> findAllByDeletedAtIsNull(Pageable pageable);
+    List<Delivery> findAllByOrderIdAndDeletedAtIsNullOrderByCreatedAtAsc(UUID orderId);
 }

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/repository/DeliveryRepository.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/repository/DeliveryRepository.java
@@ -1,0 +1,4 @@
+package com.logilink.eureka.client.delivery.domain.repository;
+
+public interface DeliveryRepository {
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/repository/DeliveryRepository.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/repository/DeliveryRepository.java
@@ -1,4 +1,9 @@
 package com.logilink.eureka.client.delivery.domain.repository;
 
-public interface DeliveryRepository {
+import com.logilink.eureka.client.delivery.domain.model.Delivery;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface DeliveryRepository extends JpaRepository<Delivery, UUID> {
 }

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/service/DeliveryService.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/service/DeliveryService.java
@@ -1,0 +1,13 @@
+package com.logilink.eureka.client.delivery.domain.service;
+
+import com.logilink.eureka.client.delivery.domain.repository.DeliveryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DeliveryService {
+    private final DeliveryRepository deliveryRepository;
+}

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/service/DeliveryService.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/service/DeliveryService.java
@@ -3,14 +3,19 @@ package com.logilink.eureka.client.delivery.domain.service;
 import com.logilink.eureka.client.delivery.common.constants.DeliveryStatus;
 import com.logilink.eureka.client.delivery.domain.model.Delivery;
 import com.logilink.eureka.client.delivery.domain.model.dto.CreateRequestDto;
+import com.logilink.eureka.client.delivery.domain.model.dto.SearchDeliveryResponseDto;
 import com.logilink.eureka.client.delivery.domain.model.dto.UpdateRequestDto;
 import com.logilink.eureka.client.delivery.domain.repository.DeliveryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -23,6 +28,7 @@ public class DeliveryService {
     @Transactional
     public Delivery createDelivery(UUID orderId, CreateRequestDto createRequestDto) {
         // Todo. 권한 검증 : 마스터 관리자만 생성 가능, 여기서 검증 하는지 게이트웨이에서 하는지 둘 다 인지
+        // Todo. orderId 검증
 
         Delivery delivery = createRequestDto.toDelivery();
         delivery.setOrderId(orderId);
@@ -57,5 +63,36 @@ public class DeliveryService {
         delivery.softDelete(LocalDateTime.now(), userId);
 
         return delivery;
+    }
+
+    // 배송 단건 조회
+    @Transactional(readOnly = true)
+    public Delivery getDelivery(UUID deliveryId) {
+        Delivery delivery = deliveryRepository.findById(deliveryId).orElseThrow();
+
+        // Todo. 예외처리 : 배송 삭제 된 경우
+
+        return delivery;
+    }
+
+    // 배송 목록 조회
+    public Page<Delivery> getDeliveryList(Pageable pageable) {
+        return deliveryRepository.findAllByDeletedAtIsNull(pageable);
+    }
+
+    // 배송 현황 검색
+    public List<SearchDeliveryResponseDto> searchDeliveryStatusList(UUID orderId) {
+        // Todo. orderId 검증
+
+        List<Delivery> deliveryList = deliveryRepository.findAllByOrderIdAndDeletedAtIsNullOrderByCreatedAtAsc(orderId);
+        List<SearchDeliveryResponseDto> responseDtoList = new ArrayList<>();
+
+        for(Delivery delivery : deliveryList) {
+            UUID deliveryId = delivery.getId();
+            DeliveryStatus status = delivery.getStatus();
+
+            responseDtoList.add(new SearchDeliveryResponseDto(deliveryId, status, orderId));
+        }
+        return responseDtoList;
     }
 }

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/service/DeliveryService.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/service/DeliveryService.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Service
@@ -46,5 +47,15 @@ public class DeliveryService {
         return  delivery;
     }
 
-    //
+    // 배송 삭제
+    @Transactional
+    public Delivery deleteDelivery(UUID deliveryId, Long userId) {
+        // Todo. 권한 : 마스터, 허브관리자 <- userId
+
+        Delivery delivery = deliveryRepository.findById(deliveryId).orElseThrow();
+
+        delivery.softDelete(LocalDateTime.now(), userId);
+
+        return delivery;
+    }
 }

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/service/DeliveryService.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/service/DeliveryService.java
@@ -76,11 +76,13 @@ public class DeliveryService {
     }
 
     // 배송 목록 조회
+    @Transactional(readOnly = true)
     public Page<Delivery> getDeliveryList(Pageable pageable) {
         return deliveryRepository.findAllByDeletedAtIsNull(pageable);
     }
 
     // 배송 현황 검색
+    @Transactional(readOnly = true)
     public List<SearchDeliveryResponseDto> searchDeliveryStatusList(UUID orderId) {
         // Todo. orderId 검증
 

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/service/DeliveryService.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/service/DeliveryService.java
@@ -1,11 +1,14 @@
 package com.logilink.eureka.client.delivery.domain.service;
 
+import com.logilink.eureka.client.delivery.common.constants.DeliveryStatus;
 import com.logilink.eureka.client.delivery.domain.model.Delivery;
 import com.logilink.eureka.client.delivery.domain.model.dto.CreateRequestDto;
+import com.logilink.eureka.client.delivery.domain.model.dto.UpdateRequestDto;
 import com.logilink.eureka.client.delivery.domain.repository.DeliveryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -15,6 +18,8 @@ import java.util.UUID;
 public class DeliveryService {
     private final DeliveryRepository deliveryRepository;
 
+    // 배송 생성
+    @Transactional
     public Delivery createDelivery(UUID orderId, CreateRequestDto createRequestDto) {
         // Todo. 권한 검증 : 마스터 관리자만 생성 가능, 여기서 검증 하는지 게이트웨이에서 하는지 둘 다 인지
 
@@ -23,4 +28,23 @@ public class DeliveryService {
         deliveryRepository.save(delivery);
         return delivery;
     }
+
+    // 배송 수정
+    @Transactional
+    public Delivery updateDelivery(UUID deliveryId, UpdateRequestDto updateRequestDto) {
+        // Todo. 권한 : 마스터, 허브관리자, 배송담당자
+
+        Delivery delivery = deliveryRepository.findById(deliveryId).orElseThrow();
+
+        if(updateRequestDto.getStatus() != null) {
+            delivery.setStatus(updateRequestDto.getStatus());
+        }
+        if(updateRequestDto.getDeliveryManagerId() != null) {
+            delivery.setDeliveryManagerId(updateRequestDto.getDeliveryManagerId());
+        }
+
+        return  delivery;
+    }
+
+    //
 }

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/service/DeliveryService.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/service/DeliveryService.java
@@ -1,13 +1,27 @@
 package com.logilink.eureka.client.delivery.domain.service;
 
+import com.logilink.eureka.client.delivery.common.BaseResponse;
+import com.logilink.eureka.client.delivery.domain.model.Delivery;
+import com.logilink.eureka.client.delivery.domain.model.dto.RequestDto;
 import com.logilink.eureka.client.delivery.domain.repository.DeliveryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class DeliveryService {
     private final DeliveryRepository deliveryRepository;
+
+    public Delivery createDelivery(UUID orderId, RequestDto requestDto) {
+        // Todo. 권한 검증 : 마스터 관리자만 생성 가능, 여기서 검증 하는지 게이트웨이에서 하는지 둘 다 인지
+
+        Delivery delivery = requestDto.toDelivery();
+        delivery.setOrderId(orderId);
+        deliveryRepository.save(delivery);
+        return delivery;
+    }
 }

--- a/src/main/java/com/logilink/eureka/client/delivery/domain/service/DeliveryService.java
+++ b/src/main/java/com/logilink/eureka/client/delivery/domain/service/DeliveryService.java
@@ -1,8 +1,7 @@
 package com.logilink.eureka.client.delivery.domain.service;
 
-import com.logilink.eureka.client.delivery.common.BaseResponse;
 import com.logilink.eureka.client.delivery.domain.model.Delivery;
-import com.logilink.eureka.client.delivery.domain.model.dto.RequestDto;
+import com.logilink.eureka.client.delivery.domain.model.dto.CreateRequestDto;
 import com.logilink.eureka.client.delivery.domain.repository.DeliveryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,10 +15,10 @@ import java.util.UUID;
 public class DeliveryService {
     private final DeliveryRepository deliveryRepository;
 
-    public Delivery createDelivery(UUID orderId, RequestDto requestDto) {
+    public Delivery createDelivery(UUID orderId, CreateRequestDto createRequestDto) {
         // Todo. 권한 검증 : 마스터 관리자만 생성 가능, 여기서 검증 하는지 게이트웨이에서 하는지 둘 다 인지
 
-        Delivery delivery = requestDto.toDelivery();
+        Delivery delivery = createRequestDto.toDelivery();
         delivery.setOrderId(orderId);
         deliveryRepository.save(delivery);
         return delivery;

--- a/src/main/resources/.env
+++ b/src/main/resources/.env
@@ -1,0 +1,6 @@
+# --- DB ---
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=delivery_db
+DB_USERNAME=postgres
+DB_PASSWORD=postgres

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,25 @@
+server:
+  port: 19097
+
 spring:
   application:
     name: delivery-service
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:delivery_db}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,3 @@
 spring:
   application:
-    name: delivery
+    name: delivery-service


### PR DESCRIPTION
#3 

### 변경사항
- Controller
    - 조회, 검색 메서드 작성 
-  Service
    - 단건 조회 로직 구현
    - 페이지로 목록 조회 로직 구현 
        - 정렬 기능 추가 : 생성일 기준으로 desc, asc 지정 가능 
    - 배송 현황 조회 기능 구현
- Repository
    - 삭제되지 않은 모든 배송 검색 함수 추가
    - 주문ID로 연관된 배송 검색 함수 추가


### 리뷰요청
- 페이지 반환 형식이 괜찮은지
- 추가적인 기능 구현이 필요한지
- 그 외의 수정사항이 있으시면 리뷰 남겨주세요